### PR TITLE
SBX-51: Implement API endpoint for creating a new email schedule

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
 
 Base = declarative_base()
 
@@ -11,3 +12,10 @@ class EmailSchedule(Base):
     subject = Column(String)
     body = Column(String)
     scheduled_time = Column(DateTime)
+
+
+def add_email_schedule(email_schedule: EmailSchedule, session: Session = None):
+    if session is None:
+        session = Session()
+    session.add(email_schedule)
+    session.commit()

--- a/database.py
+++ b/database.py
@@ -1,8 +1,14 @@
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 Base = declarative_base()
+
+engine = create_engine('sqlite:///email_schedules.db')
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
 
 class EmailSchedule(Base):
     __tablename__ = 'email_schedules'
@@ -16,6 +22,9 @@ class EmailSchedule(Base):
 
 def add_email_schedule(email_schedule: EmailSchedule, session: Session = None):
     if session is None:
-        session = Session()
+        session = SessionLocal()
     session.add(email_schedule)
     session.commit()
+    session.refresh(email_schedule)
+    session.close()
+    return email_schedule

--- a/main.py
+++ b/main.py
@@ -5,11 +5,6 @@ from database import EmailSchedule, add_email_schedule
 app = FastAPI()
 
 
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
-
-
 class EmailScheduleRequest(BaseModel):
     email: str
     subject: str
@@ -17,8 +12,21 @@ class EmailScheduleRequest(BaseModel):
     scheduled_time: str
 
 
-@app.post("/email-schedules")
+class EmailScheduleResponse(BaseModel):
+    id: int
+    email: str
+    subject: str
+    body: str
+    scheduled_time: str
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+@app.post("/email-schedules", response_model=EmailScheduleResponse)
 def create_email_schedule(email_schedule_request: EmailScheduleRequest):
     email_schedule = EmailSchedule(**email_schedule_request.dict())
-    add_email_schedule(email_schedule)
-    return {"message": "Email schedule created successfully."}
+    created_email_schedule = add_email_schedule(email_schedule)
+    return created_email_schedule

--- a/main.py
+++ b/main.py
@@ -1,7 +1,24 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from database import EmailSchedule, add_email_schedule
 
 app = FastAPI()
+
 
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
+
+
+class EmailScheduleRequest(BaseModel):
+    email: str
+    subject: str
+    body: str
+    scheduled_time: str
+
+
+@app.post("/email-schedules")
+def create_email_schedule(email_schedule_request: EmailScheduleRequest):
+    email_schedule = EmailSchedule(**email_schedule_request.dict())
+    add_email_schedule(email_schedule)
+    return {"message": "Email schedule created successfully."}

--- a/test_main.py
+++ b/test_main.py
@@ -7,6 +7,13 @@ client = TestClient(app)
 
 @patch('main.add_email_schedule')
 def test_create_email_schedule(mocked_add_email_schedule):
+    mocked_add_email_schedule.return_value = {
+        "id": 1,
+        "email": "test@example.com",
+        "subject": "Test",
+        "body": "This is a test.",
+        "scheduled_time": str(datetime.now())
+    }
     response = client.post(
         "/email-schedules",
         json={
@@ -17,5 +24,9 @@ def test_create_email_schedule(mocked_add_email_schedule):
         },
     )
     assert response.status_code == 200
-    assert response.json() == {"message": "Email schedule created successfully."}
+    assert response.json()['id'] == 1
+    assert response.json()['email'] == 'test@example.com'
+    assert response.json()['subject'] == 'Test'
+    assert response.json()['body'] == 'This is a test.'
+    assert 'scheduled_time' in response.json()
     mocked_add_email_schedule.assert_called_once()

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock, patch
+from fastapi.testclient import TestClient
+from main import app
+from datetime import datetime
+
+client = TestClient(app)
+
+@patch('main.add_email_schedule')
+def test_create_email_schedule(mocked_add_email_schedule):
+    response = client.post(
+        "/email-schedules",
+        json={
+            "email": "test@example.com",
+            "subject": "Test",
+            "body": "This is a test.",
+            "scheduled_time": str(datetime.now())
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"message": "Email schedule created successfully."}
+    mocked_add_email_schedule.assert_called_once()


### PR DESCRIPTION
This PR implements the API endpoint for creating a new email schedule. It includes updates to the FastAPI application, the database module, and the tests. The tests have been fixed to mock the add_email_schedule function instead of the database session.

### Test Plan

pytest